### PR TITLE
reworking proxy

### DIFF
--- a/os-bases/centos/usr/lib/contractor/resources/centos.toml
+++ b/os-bases/centos/usr/lib/contractor/resources/centos.toml
@@ -34,7 +34,7 @@ initrd {{ __pxe_location }}/centos-installer/6.initrd
 boot
 """
   template = """install
-url --url=http://{{ mirror_server }}/centos/6.10/os/x86_64{% if mirror_proxy %} --proxy={{ mirror_proxy }}{% endif %}
+url --url=http://{{ mirror_server }}/centos/6.10/os/x86_64{% if http_proxy %} --proxy={{ http_proxy }}{% endif %}
 lang en_US.UTF-8
 keyboard us
 network --hostname={{ _fqdn }}
@@ -80,7 +80,7 @@ initrd {{ __pxe_location }}/centos-installer/7.initrd
 boot
 """
   template = """install
-url --url=http://{{ mirror_server }}/centos/7/os/x86_64{% if mirror_proxy %} --proxy={{ mirror_proxy }}{% endif %}
+url --url=http://{{ mirror_server }}/centos/7/os/x86_64{% if http_proxy %} --proxy={{ http_proxy }}{% endif %}
 lang en_US.UTF-8
 keyboard us
 network --hostname={{ _fqdn }}

--- a/os-bases/ubuntu/usr/lib/contractor/resources/ubuntu.toml
+++ b/os-bases/ubuntu/usr/lib/contractor/resources/ubuntu.toml
@@ -96,7 +96,7 @@ d-i netcfg/hostname string {{ _hostname }}
 d-i mirror/country string manual
 d-i mirror/http/hostname string {{ mirror_server }}
 d-i mirror/http/directory string /ubuntu/
-d-i mirror/http/proxy string {{ mirror_proxy }}
+d-i mirror/http/proxy string {{ http_proxy }}
 
 # Suite to install.
 d-i mirror/suite string {{ distro_version }}

--- a/utility/utility/usr/lib/contractor/resources/utility.toml
+++ b/utility/utility/usr/lib/contractor/resources/utility.toml
@@ -6,7 +6,7 @@
   'cpu_count': 2
   'disk_size': 100
   '>user_list' = [ { name = 'jbuser', group = 'jbgroup', password_hash = '$6$jbuserjbuser$S.RvuUr1xgPvZpus7zVWzPtjb5MiECT5jQI9DFLIF10HF3Vr2SyCjVy9hBdYuIoglBZQplBp9UYWCgfTSNghl/', sudo_list = [ 'ALL=(ALL) ALL' ] } ]
-  '>repo_list' = [ { distribution = 'stable', type = 'apt', uri = 'http://dl.google.com/linux/chrome/deb/', components = [ 'main' ], key_uri = 'https://dl-ssl.google.com/linux/linux_signing_key.pub', proxy = '{{ mirror_proxy|default( "local" ) }}' } ]
+  '>repo_list' = [ { distribution = 'stable', type = 'apt', uri = 'http://dl.google.com/linux/chrome/deb/', components = [ 'main' ], key_uri = 'https://dl-ssl.google.com/linux/linux_signing_key.pub', proxy = '{{ http_proxy|default( "local" ) }}' } ]
   '>package_list' = [ 'xubuntu-desktop', 'remmina', 'icedtea-8-plugin', 'google-chrome-stable', 'xorgxrdp', 'xrdp' ]
   '>postinstall_command_list' = [ 'rm /etc/xrdp/rsakeys.ini /etc/xrdp/*.pem',
                                   '/usr/bin/xrdp-keygen xrdp auto',


### PR DESCRIPTION
renamed mirror_proxy to http_proxy, http_proxy is used for all proxying except communicating with contractor, that is still contractor_proxy